### PR TITLE
Fix Describe Bug

### DIFF
--- a/UserAccessVisualization/.gitignore
+++ b/UserAccessVisualization/.gitignore
@@ -1,0 +1,2 @@
+/Referenced Packages/
+/.settings/

--- a/UserAccessVisualization/.project
+++ b/UserAccessVisualization/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>com.salesforce.ide.builder.online</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>com.salesforce.ide.nature.default</nature>
+		<nature>com.salesforce.ide.nature.online</nature>
 	</natures>
 </projectDescription>

--- a/UserAccessVisualization/src/classes/UserAccessDetailsController.cls
+++ b/UserAccessVisualization/src/classes/UserAccessDetailsController.cls
@@ -274,7 +274,6 @@ public class UserAccessDetailsController {
     public List<NameLabel> getObjectLabels() {
         if (null == xObjectLabels) {
             List<NameLabel> result = new List<NameLabel>();
-            Map<String,SObjectType> describe = Schema.getGlobalDescribe();
 
             // We can't really depend on describe to give us the object we want
             // since that includes a lot of stuff that doesn't support CRUD
@@ -286,8 +285,14 @@ public class UserAccessDetailsController {
             // for now.                   
             for (ObjectPermissions op : [SELECT SObjectType FROM ObjectPermissions 
                                           WHERE Parent.Profile.Name = 'System Administrator']) {
-                result.add(new NameLabel(op.SObjectType, 
-                                         describe.get(op.SObjectType).getDescribe().getLabel()));
+				// Try to get the label, but use the API name if we do not have a describe for the
+				// object. This may occur because this class's version is too low and does not support
+				// the new object.
+				Type sObjectType = Type.forName('Schema.'+op.SObjectType);
+				result.add(
+                	new NameLabel(op.SObjectType, 
+                                 sObjectType==null?op.SObjectType:((SObject)sObjectType.newInstance()).getSObjectType().getDescribe().getLabel())
+                );
             }
             result.sort();
             xObjectLabels = result;

--- a/UserAccessVisualization/src/classes/UserAccessDetailsController.cls-meta.xml
+++ b/UserAccessVisualization/src/classes/UserAccessDetailsController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>28.0</apiVersion>
+    <apiVersion>35.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/UserAccessVisualization/src/package.xml
+++ b/UserAccessVisualization/src/package.xml
@@ -20,5 +20,5 @@
         <members>*</members>
         <name>StaticResource</name>
     </types>
-    <version>25.0</version>
+    <version>33.0</version>
 </Package>


### PR DESCRIPTION
This fix changes the code to API version 35 so some new objects can be described, and provides a small fix that prevents a System.NullPointerException when the ObjectPermissions query returns
SObjectType values that cannot be described.
